### PR TITLE
Add agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agents Guide
+
+## Setup
+
+If `nix` is not installed, use the Determinate Systems installer:
+
+```sh
+$ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
+$ . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+```
+
+Ensure flake inputs are downloaded before running in an offline sandbox. This project has
+`flake.lock` files in the repository root, `internal/`, and `plugins/`:
+
+```sh
+$ nix flake archive
+$ nix flake archive ./internal/
+$ nix flake archive ./plugins/
+```
+
+## Testing
+
+```sh
+$ nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going
+```
+
+These flags will give you the most verbose output for debugging. When running in an offline sandbox, you should append `--offline`.
+
+## Formatting
+
+`nix flake check` will also check if source files are formatted correctly. If there is a formatting issue, run `nix fmt` to fix it.


### PR DESCRIPTION
## Summary
- document how the agent should use nix tooling
- clarify archiving instructions for all flake.lock files

## Testing
- `nix flake archive` (root)
- `nix flake archive ./internal`
- `nix flake archive ./plugins`
- `nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going`


------
https://chatgpt.com/codex/tasks/task_e_68622a8496c88326a68eedbacf1cc50b