### PR TITLE
Fix neovim healthcheck warnings

### DIFF
--- a/pkgs/LazyVim.nix
+++ b/pkgs/LazyVim.nix
@@ -77,8 +77,7 @@ in
     go
     php83
     php83Packages.composer
-    python312Packages.python
-    python312Packages.pip
+    (python312Packages.python.withPackages (ps: with ps; [ pip ]))
     cargo
     ruby
     nodePackages.nodejs
@@ -140,7 +139,6 @@ in
             "WARNING javac: not available"
             "WARNING java: not available"
             "WARNING julia: not available"
-            "WARNING pip: not available"
             # OK: Nix build sandbox will always prevent access to github API
             "WARNING Failed to check GitHub API rate limit status"
           ];


### PR DESCRIPTION
Fix 'pip not available' warning in Neovim's Mason healthcheck by correctly bundling pip with Python.

The original configuration for `extraPackages` in `pkgs/LazyVim.nix` listed `python312Packages.python` and `python312Packages.pip` separately. This did not create a Python environment where `pip` was accessible as a module, causing the `mason.nvim` healthcheck to report "WARNING pip: not available". This PR bundles `pip` directly with the Python package using `python.withPackages`, ensuring `pip` is properly integrated and resolving the healthcheck warning. The warning is then removed from the `ignoreLines` list.