### PR TITLE
Fix mason health check

### DIFF
--- a/pkgs/LazyVim.nix
+++ b/pkgs/LazyVim.nix
@@ -11,6 +11,7 @@
   gnutar,
   go,
   gzip,
+  julia,
   lazygit,
   nodePackages,
   php83,
@@ -75,6 +76,7 @@ in
     gzip
     gnutar
     go
+    julia
     php83
     php83Packages.composer
     (python312Packages.python.withPackages (ps: with ps; [ pip ]))
@@ -138,7 +140,6 @@ in
             "ERROR Registry `github.com/mason-org/mason-registry [uninstalled]` is not installed"
             "WARNING javac: not available"
             "WARNING java: not available"
-            "WARNING julia: not available"
             # OK: Nix build sandbox will always prevent access to github API
             "WARNING Failed to check GitHub API rate limit status"
           ];


### PR DESCRIPTION
## Summary
- install `julia` for the mason health check
- drop the ignored `julia` warning from mason check

## Testing
- `nix build .#checks.x86_64-linux.LazyVim-tests-checkhealth-mason --accept-flake-config --show-trace --print-build-logs --no-link --keep-failed`
- `nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going`

------
https://chatgpt.com/codex/tasks/task_e_68636a1a2d9883269aa7fe8758c46b22