### PR TITLE
Fix fzf-lua healthcheck

### DIFF
--- a/pkgs/LazyVim.nix
+++ b/pkgs/LazyVim.nix
@@ -46,7 +46,14 @@ in
     # FIXME: Not being picked up by LazyVim.json dependency scan
     plugins."blink.cmp".spec
     plugins."friendly-snippets".spec
-    plugins."fzf-lua".spec
+    (
+      plugins."fzf-lua".spec
+      // {
+        dependencies = [
+          plugins."mini.icons".spec
+        ];
+      }
+    )
     plugins."neo-tree.nvim".spec
     plugins."snacks.nvim".spec
 
@@ -122,10 +129,7 @@ in
           loadLazyPluginName = "fzf-lua";
           checkError = true;
           checkWarning = true;
-          ignoreLines = [
-            # FIXME: I think we should be able to install these plugins
-            "WARNING `nvim-web-devicons` or `mini.icons` not found"
-          ];
+          ignoreLines = [ ];
         };
 
         checkhealth-mason = neovim-checkhealth.override {

--- a/pkgs/neovim-checkhealth.nix
+++ b/pkgs/neovim-checkhealth.nix
@@ -31,6 +31,9 @@ runCommand "checkhealth-${pluginName}"
         "--headless"
       ]
       ++ lazyLoadCmd
+      ++ [
+        "+sleep 5"
+      ]
       ++ checkCmd
       ++ [
         "+w!out.txt"


### PR DESCRIPTION
## Summary
- load `mini.icons` only when `fzf-lua` starts
- wait longer before running Neovim health checks

## Testing
- `nix build .#checks.x86_64-linux.LazyVim-tests-checkhealth-fzf-lua --accept-flake-config --show-trace --print-build-logs --no-link`

------
https://chatgpt.com/codex/tasks/task_e_6863677e29ac8326b58e343d9c793f01