### PR TITLE
Fix snacks healthcheck

### DIFF
--- a/pkgs/LazyVim.nix
+++ b/pkgs/LazyVim.nix
@@ -8,6 +8,7 @@
   chafa,
   curl,
   fzf,
+  ghostscript,
   gnutar,
   go,
   gzip,
@@ -82,6 +83,7 @@ in
     cargo
     ruby
     nodePackages.nodejs
+    ghostscript
   ] ++ (lib.lists.optionals (lib.meta.availableOn stdenv.hostPlatform julia) [ julia ]);
 }).overrideAttrs
   (
@@ -176,8 +178,6 @@ in
               "ERROR None of the tools found: 'magick', 'convert'"
               "ERROR `magick` is required to convert images. Only PNG files will be displayed."
               "WARNING Image rendering in docs with missing treesitter parsers won't work"
-              "ERROR Tool not found: 'gs'"
-              "WARNING `gs` is required to render PDF files"
               "ERROR None of the tools found: 'tectonic', 'pdflatex'"
               "WARNING `tectonic` or `pdflatex` is required to render LaTeX math expressions"
               "ERROR Tool not found: 'mmdc'"


### PR DESCRIPTION
## Summary
- unignore the missing `gs` check
- add ghostscript to the LazyVim wrapper

## Testing
- `nix build .#checks.x86_64-linux.LazyVim-tests-checkhealth-snacks --accept-flake-config --show-trace --print-build-logs`
- `nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going`

------
https://chatgpt.com/codex/tasks/task_e_6863716cc1b08326889694566c49b011