### PR TITLE
Fix snacks checkhealth dependency

### DIFF
--- a/pkgs/LazyVim.nix
+++ b/pkgs/LazyVim.nix
@@ -12,6 +12,7 @@
   gnutar,
   go,
   gzip,
+  imagemagick,
   jdk,
   julia,
   lazygit,
@@ -90,6 +91,7 @@ in
 
     # snacks
     ghostscript
+    imagemagick
   ] ++ (lib.lists.optionals (lib.meta.availableOn stdenv.hostPlatform julia) [ julia ]);
 }).overrideAttrs
   (
@@ -174,8 +176,6 @@ in
             "WARNING dashboard did not open: `headless`"
             "WARNING setup {disabled}"
             "ERROR None of the tools found: 'kitty', 'wezterm', 'ghostty'"
-            "ERROR None of the tools found: 'magick', 'convert'"
-            "ERROR `magick` is required to convert images. Only PNG files will be displayed."
             "WARNING Image rendering in docs with missing treesitter parsers won't work"
             "ERROR None of the tools found: 'tectonic', 'pdflatex'"
             "WARNING `tectonic` or `pdflatex` is required to render LaTeX math expressions"


### PR DESCRIPTION
## Summary
- include ImageMagick for snacks healthcheck
- stop ignoring "magick" tool warning
- drop unneeded ignore line for missing magick tool

## Testing
- `nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going`
- `nix build .#checks.x86_64-linux.LazyVim-tests-checkhealth-snacks --accept-flake-config --show-trace --print-build-logs`
- `nix fmt --accept-flake-config`


------
https://chatgpt.com/codex/tasks/task_e_686436ee06688326b2044aefb1af68fe