### PR TITLE
Fix snacks health check

### DIFF
--- a/pkgs/LazyVim.nix
+++ b/pkgs/LazyVim.nix
@@ -182,7 +182,6 @@ in
             "ERROR Tool not found: 'mmdc'"
             "WARNING `mmdc` is required to render Mermaid diagrams"
             "ERROR your terminal does not support the kitty graphics protocol"
-            "ERROR is not ready"
             "WARNING Missing Treesitter languages"
           ];
         };

--- a/pkgs/LazyVim.nix
+++ b/pkgs/LazyVim.nix
@@ -21,6 +21,7 @@
   php83Packages,
   python312Packages,
   ruby,
+  tectonic,
   ueberzugpp,
   unzip,
   viu,
@@ -89,9 +90,10 @@ in
     unzip
     wget
 
-    # snacks
+    # snacks healthcheck dependencies
     ghostscript
     imagemagick
+    tectonic
   ] ++ (lib.lists.optionals (lib.meta.availableOn stdenv.hostPlatform julia) [ julia ]);
 }).overrideAttrs
   (
@@ -177,7 +179,6 @@ in
             "WARNING setup {disabled}"
             "ERROR None of the tools found: 'kitty', 'wezterm', 'ghostty'"
             "WARNING Image rendering in docs with missing treesitter parsers won't work"
-            "ERROR None of the tools found: 'tectonic', 'pdflatex'"
             "WARNING `tectonic` or `pdflatex` is required to render LaTeX math expressions"
             "ERROR Tool not found: 'mmdc'"
             "WARNING `mmdc` is required to render Mermaid diagrams"

--- a/pkgs/LazyVim.nix
+++ b/pkgs/LazyVim.nix
@@ -179,7 +179,6 @@ in
             "WARNING setup {disabled}"
             "ERROR None of the tools found: 'kitty', 'wezterm', 'ghostty'"
             "WARNING Image rendering in docs with missing treesitter parsers won't work"
-            "WARNING `tectonic` or `pdflatex` is required to render LaTeX math expressions"
             "ERROR Tool not found: 'mmdc'"
             "WARNING `mmdc` is required to render Mermaid diagrams"
             "ERROR your terminal does not support the kitty graphics protocol"


### PR DESCRIPTION
## Summary
- add `tectonic` for snacks healthcheck
- comment clarifies snacks dependencies
- stop ignoring LaTeX tooling line

## Testing
- `nix fmt --accept-flake-config`
- `nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686441a0e5788326a9501ee40c59552d