### PR TITLE
Fix snacks healthcheck

### DIFF
--- a/pkgs/LazyVim.nix
+++ b/pkgs/LazyVim.nix
@@ -181,7 +181,6 @@ in
             "WARNING setup {disabled}"
             "WARNING Image rendering in docs with missing treesitter parsers won't work"
             "WARNING The `latex` treesitter parser is required to render LaTeX math expressions"
-            "ERROR your terminal does not support the kitty graphics protocol"
             "ERROR is not ready"
             "WARNING Missing Treesitter languages"
           ];

--- a/pkgs/neovim-checkhealth.nix
+++ b/pkgs/neovim-checkhealth.nix
@@ -56,6 +56,8 @@ runCommand "checkhealth-${pluginName}"
       DISPLAY = lib.optionalString stdenv.isLinux ":0";
       LOCALE_ARCHIVE = lib.optionalString stdenv.isLinux "${glibcLocales}/lib/locale/locale-archive";
       LANG = "en_US.UTF-8";
+      TERM = "kitty";
+      KITTY_PID = "1";
     };
   }
   ''


### PR DESCRIPTION
## Summary
- set TERM and KITTY_PID when running checkhealth
- adjust snacks healthcheck ignores to drop kitty protocol warning

## Testing
- `nix build .#checks.x86_64-linux.LazyVim-tests-checkhealth-snacks --accept-flake-config --show-trace --print-build-logs --no-link`
- `nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going`


------
https://chatgpt.com/codex/tasks/task_e_6864541bb0088326a4436f2ffa3d37da